### PR TITLE
Fix exception when toggling linear/log scale

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -128,7 +128,7 @@ export class AppComponent {
     // adding first graph
     // @ts-ignore
     this.chartOptions.series[0] = {
-      data: selectedChannelData,
+      data: selectedChannelData ?? [],
       type: this.graphSmoothEnabled ? 'spline' : 'line',
       name: decodeChannelName(this.selectedChannel?.commandId),
     };


### PR DESCRIPTION
Highcharts is throwing an exception when updating the chart after selecting a menu item (like linear/log scale) without an ADY file loaded.  Appears to be checking the length of the chart data, which is undefined in this code path.

Fix is to pass an empty array vs undefined/null in this scenario.