### PR TITLE
Define helper function for debug statements vs console.log directly

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,6 +2,7 @@ import {Component} from '@angular/core';
 import {AudysseyInterface} from './interfaces/audyssey-interface';
 import {DetectedChannel} from './interfaces/detected-channel';
 import {decodeChannelName} from './helper-functions/decode-channel-name.pipe';
+import {DEBUG} from './helper-functions/debug';
 
 import * as Highcharts from 'highcharts';
 // import Sonification from 'highcharts/modules/sonification';
@@ -37,7 +38,7 @@ export class AppComponent {
   graphSmoothEnabled = false;
 
   chartCallback: Highcharts.ChartCallbackFunction = (chart) => {
-    console.log('Highcharts loaded');
+    DEBUG('Highcharts loaded');
     if (chart.options.exporting?.menuItemDefinitions)
     {
       chart.options.exporting.menuItemDefinitions['xScale'].onclick = () => {
@@ -67,12 +68,12 @@ export class AppComponent {
   }
 
   processDataWithWorker(json: AudysseyInterface) {
-    console.log(json);
+    DEBUG(json);
 
     if (typeof Worker !== 'undefined') { // if supported
       const worker = new Worker(new URL('./helper-functions/bg-calculator.worker', import.meta.url));
       worker.onmessage = ({ data }) => {
-        console.log('Got a message from Web-Worker');
+        DEBUG('Got a message from Web-Worker');
         this.calculatedChannelsData = data;
         this.selectedChannel = json.detectedChannels[0];
         this.updateChart();
@@ -87,7 +88,7 @@ export class AppComponent {
   }
 
   updateChart() {
-    console.log('updateChart()')
+    DEBUG('updateChart()')
 
     const XMin = 10, XMax = 24000;
 
@@ -199,7 +200,7 @@ export class AppComponent {
           .filter(point => !(point.y == 0 && (point.x == 20 || point.x == 20000))),
       ].sort((a, b) => a.x! - b.x!);
     }
-    console.log('data', data);
+    DEBUG('data', data);
 
 
     if (this.audysseyData.enTargetCurveType) {
@@ -224,7 +225,7 @@ export class AppComponent {
   }
 
   playChart(ev?: Event | Highcharts.Dictionary<any> | undefined) {
-    console.log('playChart', ev)
+    DEBUG('playChart', ev)
     // this.chartObj?.toggleSonify();
   }
 

--- a/src/app/helper-functions/calculate-points.ts
+++ b/src/app/helper-functions/calculate-points.ts
@@ -1,4 +1,5 @@
 import {abs as magnitude, complex, Complex, fft} from "mathjs";
+import {DEBUG} from "./debug";
 
 export function calculatePoints(responseDataValues: string[], enableSmoothing = true) {
   if (!responseDataValues || !responseDataValues.length) return [];
@@ -48,7 +49,7 @@ export function calculatePoints(responseDataValues: string[], enableSmoothing = 
   });
 
   // console.log('points', points.length)
-  console.log('filteredPoints', filteredPoints.length)
+  DEBUG('filteredPoints', filteredPoints.length)
 
   return filteredPoints;
 }

--- a/src/app/helper-functions/debug.ts
+++ b/src/app/helper-functions/debug.ts
@@ -1,0 +1,3 @@
+export function DEBUG(message?: any, ...optionalParams: any[]): void {
+    console.log(message, ...optionalParams);
+}


### PR DESCRIPTION
Push all debug statements to a common choke point so they can easily be disabled in a production build/release, or one can quickly cleanup the console output to focus on a specific problem.